### PR TITLE
Add traefik 3.3 + 3.4 + option 'fastProxy'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,27 @@
 # Traefik vs Nginx Benchmark
 
 ```
-# Traefik v3.0
-wrk -t20 -c1000 -d3s -H "Host: benchmark.whoami" --latency  http://127.0.0.1:8000/bench
+# initial startup
+docker compose up -d
 
-# Traefik v2.9
-wrk -t20 -c1000 -d3s -H "Host: benchmark.whoami" --latency  http://127.0.0.1:8002/bench
+# Pure Whoami
+wrk -t20 -c1000 -d3s -H "Host: benchmark.whoami" --latency  http://127.0.0.1:8080/bench
 
 # Nginx
 wrk -t20 -c1000 -d3s -H "Host: benchmark.whoami" --latency  http://127.0.0.1:8001/bench
 
-# Pure Whoami
-wrk -t20 -c1000 -d3s -H "Host: benchmark.whoami" --latency  http://127.0.0.1:8003/bench
+# Traefik v2.9
+wrk -t20 -c1000 -d3s -H "Host: benchmark.whoami" --latency  http://127.0.0.1:8029/bench
+
+# Traefik v3.0
+wrk -t20 -c1000 -d3s -H "Host: benchmark.whoami" --latency  http://127.0.0.1:8030/bench
+
+# Traefik v3.3
+wrk -t20 -c1000 -d3s -H "Host: benchmark.whoami" --latency  http://127.0.0.1:8033/bench
+
+# Traefik v3.4-RC1
+wrk -t20 -c1000 -d3s -H "Host: benchmark.whoami" --latency  http://127.0.0.1:8034/bench
+
+# final shutdown
+docker compose down
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,32 @@
-version: "3.9"
-
 services:
+  traefik-v3.4:
+    image: "traefik:v3.4.0-rc1"
+    command:
+      - "--api.insecure=true"
+      - "--providers.docker=true"
+      - "--providers.docker.exposedbydefault=false"
+      - "--entrypoints.web.address=:8000"
+      - "--serverstransport.maxidleconnsperhost=100000"
+      - "--experimental.fastProxy"
+    ports:
+      - "8034:8000"
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+
+  traefik-v3.3:
+    image: "traefik:v3.3.5"
+    command:
+      - "--api.insecure=true"
+      - "--providers.docker=true"
+      - "--providers.docker.exposedbydefault=false"
+      - "--entrypoints.web.address=:8000"
+      - "--serverstransport.maxidleconnsperhost=100000"
+      - "--experimental.fastProxy"
+    ports:
+      - "8033:8000"
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+
   traefik-v3.0:
     image: "traefik:v3.0"
     command:
@@ -10,7 +36,7 @@ services:
       - "--entrypoints.web.address=:8000"
       - "--serverstransport.maxidleconnsperhost=100000"
     ports:
-      - "8000:8000"
+      - "8030:8000"
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock:ro"
 
@@ -20,10 +46,10 @@ services:
       - "--api.insecure=true"
       - "--providers.docker=true"
       - "--providers.docker.exposedbydefault=false"
-      - "--entrypoints.web.address=:8002"
+      - "--entrypoints.web.address=:8000"
       - "--serverstransport.maxidleconnsperhost=100000"
     ports:
-      - "8002:8002"
+      - "8029:8000"
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock:ro"
 
@@ -38,7 +64,7 @@ services:
   whoami-1:
     image: "containous/whoami"
     ports:
-      - "8003:80"
+      - "8080:80"
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.go-benchmark.rule=Host(`benchmark.whoami`)"


### PR DESCRIPTION
I'Ve added Treafik v3.3 and 3.4-RC1. Also I've added [the option `--experimental.fastProxy`](https://doc.traefik.io/traefik/master/user-guides/fastproxy/) which I was very curious about. It was featured in their blog:

https://traefik.io/blog/traefik-proxy-v3-2-a-munster-release/

> The Fast Proxy engine is a high-performance reverse proxy designed to enhance the performance of routing based on a zero allocation pipeline. This new engine significantly improves performance, boasting a remarkable 50% increase in speed compared to the standard engine.

I'm a bit disappointed since I couldn't measure any performance gains from it. Same applies to the latest Traefik releases.

Maybe you can give it a try and post a follow up blog post on it.